### PR TITLE
run.c: Fix uninitialized field

### DIFF
--- a/run.c
+++ b/run.c
@@ -279,6 +279,7 @@ void read_checkpoint(char* checkpoint, Config* config, TransformerWeights* weigh
     // memory map the Transformer weights
     *data = (float*)(checkpoint + sizeof(Config));    
     float* weights_ptr = *data;
+    *fd = -1;
     memory_map_weights(weights, config, weights_ptr, shared_weights);
 }
 #else


### PR DESCRIPTION
The `fd` field in the `Transformer` structure is not initialized. Because of that, on certain code paths, calls to the system functions will use a wrong file descriptor. This causes an assertion failure in Unikraft.

Workaround for this was the commenting out of the `CONFIG_LIBUKDEBUG_ENABLE_ASSERT` configuration option in Unikraft.

Fix this by initializing `fd` to -1. This makes the current code fully functional on Unikraft, eliminating the assertion failure.